### PR TITLE
Refactored prompts, added a function to verify concept scope

### DIFF
--- a/api/agents/feynman_student_prompt.py
+++ b/api/agents/feynman_student_prompt.py
@@ -3,7 +3,7 @@ from langchain.prompts import PromptTemplate
 from langchain.output_parsers import PydanticOutputParser
 from langchain_core.pydantic_v1 import BaseModel, Field
 
-base_prompt = """
+base_student_prompt = """
 ### Context
 The user is currently learning through the Feynman technique, where you act as a student and the user will attempt to teach you a concept. You act as a "dumb" student, but under the hood, you ask expert questions to probe the user's understanding of a concept.
 
@@ -44,17 +44,28 @@ class FeynmanResponse(BaseModel):
     )
 
 
-parser = PydanticOutputParser(pydantic_object=FeynmanResponse)
+feynman_student_prompt_parser = PydanticOutputParser(pydantic_object=FeynmanResponse)
 
-prompt_template = PromptTemplate.from_template(base_prompt)
-prompt = prompt_template.format(
+feynman_student_prompt_template = PromptTemplate(
+    template=base_student_prompt,
+    input_variables=[
+        "concept",
+        "game_mode",
+        "depth",
+        "student_persona",
+        "session_plan",
+    ],
+    partial_variables={
+        "output_format": feynman_student_prompt_parser.get_format_instructions()
+    },
+)
+feynman_student_prompt = feynman_student_prompt_template.format(
     concept="Quantum Mechanics",
     game_mode="Explain to a 5 year old, user needs to explain using very simple language and examples",
     depth="beginner - just ask really basic information",
     student_persona="5 year old, you don't know a lot of things, if the user mentions something a 5 year old wouldn't know, you ask them to explain again in the words of a 5 year old",
     session_plan="What is quantum mechanics?",
-    output_format=parser.get_format_instructions(),
 )
 
 if __name__ == "__main__":
-    print(prompt)
+    print(feynman_student_prompt)

--- a/api/agents/lesson_verification_prompt.py
+++ b/api/agents/lesson_verification_prompt.py
@@ -1,0 +1,63 @@
+from langchain.prompts import PromptTemplate
+from langchain.output_parsers import PydanticOutputParser
+from langchain_core.pydantic_v1 import BaseModel, Field
+
+verify_lesson_base_prompt = """
+Concept to explain: {concept}
+Lesson objectives: {objectives}
+
+Assess if the provided lesson objectives for the concept above are scoped specifically and narrowly enough to be covered in a 15-minute session and can be done fully through speech explanations alone. 
+
+Reject the objectives if:
+1. There are too many goals to be covered within 15 minutes.
+2. Goals are not specific enough to form a clear, focused lesson plan.
+3. Explanation really requires visual aids, only speech explanations are supported currently.
+
+Feedback should be concise, include whether the objectives meet these criteria and concise suggestions for refinement.
+
+Example 1 (Too Many Goals):
+Concept: Mathematics - Basic Algebra
+Lesson Objectives: Introduce variables, solving linear equations, quadratic equations, graphing functions, and polynomials.
+feedback: Too many objectives
+suggestion: Consider focusing on one topic, such as "solving linear equations."
+
+Example 2 (Goals Not Specific Enough):
+Concept: Mathematics - Geometry
+Lesson Objectives: Understand shapes and their properties
+feedback: Objectives are too vague
+suggestion: A more specific objective could be "Identify and compare properties of 2D shapes, ie triangles and rectangles."
+
+Output Format:
+{format_instructions}
+"""
+
+
+class ConceptVerificationResponse(BaseModel):
+    feasible: bool = Field(
+        description="whether the concept and objectives are feasible to teach within the timeframe"
+    )
+    feedback: str = Field(
+        description="concise reason for failure, leave empty if feasible"
+    )
+    suggestion: str = Field(
+        description="concise suggestions for improvement, leave empty if feasible"
+    )
+
+
+verify_lesson_parser = PydanticOutputParser(pydantic_object=ConceptVerificationResponse)
+
+verify_lesson_prompt_template = PromptTemplate(
+    template=verify_lesson_base_prompt,
+    input_variables=["concept", "objectives"],
+    partial_variables={
+        "format_instructions": verify_lesson_parser.get_format_instructions()
+    },
+)
+verify_lesson_prompt = verify_lesson_prompt_template.format(
+    concept="Quantum Mechanics",
+    objectives="Students will understand the basic principles of quantum mechanics and be able to apply them to solve simple problems.",
+    format_instructions=verify_lesson_parser.get_format_instructions(),
+)
+
+if __name__ == "__main__":
+    print(verify_lesson_prompt)


### PR DESCRIPTION
### Summary of changes
- New backend endpoint that takes in a concept and its scope and checks if it is feasible to conduct

```python
Example Input:
{
  "lesson_concept": "Comprehensive Overview of Calculus",
  "lesson_objectives": [
    "Introduce the concept of limits and continuity",
    "Explain differentiation and its applications",
    "Cover the fundamentals of integration",
    "Discuss the basics of multivariable calculus",
    "Provide examples of differential equations"
  ]
}

Output:
{"passed_verification": false, "feedback": "Too many objectives", "suggestion": "Focus on a narrower aspect of calculus, such as 'Introduce the concept of limits and continuity' exclusively.", "success": true}"
```

Closes #29 