### PR TITLE
Cumulative bug fixes

### DIFF
--- a/api/agents/feynman_student_prompt_v6.py
+++ b/api/agents/feynman_student_prompt_v6.py
@@ -8,6 +8,7 @@ base_student_prompt = """
 The user is learning using the Feynman method, where
 - User will teach you something
 - You act as a student who knows nothing about the topic. Further on, you will be provided with a persona and an assumed knowledge level as a student.
+- You receive user transcripts which might be noisy. If a user repeats themselves, it is likely that they are trying to fix transcription mistakes
 
 ### Your role is to
 1) Listen to a user's lesson explanation. Ask for "why does it work this way?" or "can you explain this simpler?" questions or ask for clarification or examples or analogies. If you've identified gaps in the user's explanation, probe them with questions to test their understanding. 

--- a/frontend/src/backendEndpoints.ts
+++ b/frontend/src/backendEndpoints.ts
@@ -9,3 +9,4 @@ export const VERIFY_LESSON_SCOPE_ENDPOINT = `${baseUrl}/verify_lesson_scope`;
 export const CREATE_QUESTION_ANALYSIS = `${baseUrl}/analyze_question_response`;
 export const CREATE_POST_SESSION_ANALYSIS = `${baseUrl}/analyze_session`;
 export const GET_POST_SESSION_ANALYSIS_ENDPOINT = `${baseUrl}/get_post_session_analysis`;
+export const CHECK_POST_SESSION_ANALYSIS_EXISTS = `${baseUrl}/check_post_session_analysis_exists`

--- a/frontend/src/components/Countdown.tsx
+++ b/frontend/src/components/Countdown.tsx
@@ -8,10 +8,15 @@ export type Timer = {
 
 export interface CountdownTimerProps {
   minutes: number;
+  pauseTimer: boolean;
   onTimeUp: () => void;
 }
 
-const CountdownTimer = ({ minutes, onTimeUp }: CountdownTimerProps) => {
+const CountdownTimer = ({
+  minutes,
+  pauseTimer,
+  onTimeUp,
+}: CountdownTimerProps) => {
   const refTime = new Date().getTime() + minutes * 60000;
   const [timeLeft, setTimeLeft] = useState<Timer>(calculateTimeLeft(refTime));
 
@@ -31,11 +36,13 @@ const CountdownTimer = ({ minutes, onTimeUp }: CountdownTimerProps) => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const timeLeftTemp = calculateTimeLeft(refTime);
-      setTimeLeft(timeLeftTemp);
-      if (timeLeftTemp.minutes === 0 && timeLeftTemp.seconds === 0) {
-        onTimeUp();
-        clearInterval(interval);
+      if (!pauseTimer) {
+        const timeLeftTemp = calculateTimeLeft(refTime);
+        setTimeLeft(timeLeftTemp);
+        if (timeLeftTemp.minutes === 0 && timeLeftTemp.seconds === 0) {
+          onTimeUp();
+          clearInterval(interval);
+        }
       }
     }, 1000);
 

--- a/frontend/src/routes/_layout/sessions_.analysis.$sessionId.lazy.tsx
+++ b/frontend/src/routes/_layout/sessions_.analysis.$sessionId.lazy.tsx
@@ -76,7 +76,11 @@ function PostSessionAnalysisComponent() {
             <Stack p={"md"} spacing={"xs"}>
               {haveKnowledgeGaps ? (
                 <>
-                  <Text>{knowledge_gaps}</Text>
+                  <Box>
+                    {knowledge_gaps.map((gaps, idx) => (
+                      <Text key={`knowledge-gaps-${idx}`}>{gaps}</Text>
+                    ))}
+                  </Box>
                   <Flex p={"md"} wrap={"wrap"} gap={"xl"} justify={"center"}>
                     {easier_topics.map((topic, key) => (
                       <Button

--- a/frontend/src/routes/_layout/sessions_.new.lazy.tsx
+++ b/frontend/src/routes/_layout/sessions_.new.lazy.tsx
@@ -285,6 +285,7 @@ function NewSessionConfigurationComponent() {
         title: "Error",
         message: `Failed to create session. Please try again. ${error}`,
         color: "red",
+        autoClose: 2000,
       });
       prevStep();
       return;

--- a/frontend/src/routes/_layout/sessions_.new.lazy.tsx
+++ b/frontend/src/routes/_layout/sessions_.new.lazy.tsx
@@ -266,6 +266,8 @@ function NewSessionConfigurationComponent() {
         }, 2000);
         return;
       }
+
+      // Handle failure, reset state or try again
       notifications.update({
         id: notificationId,
         color: "red",
@@ -284,6 +286,7 @@ function NewSessionConfigurationComponent() {
         message: `Failed to create session. Please try again. ${error}`,
         color: "red",
       });
+      prevStep();
       return;
     }
   };

--- a/frontend/src/routes/_layout_no_sidebar/sessions_.run.$sessionId.lazy.tsx
+++ b/frontend/src/routes/_layout_no_sidebar/sessions_.run.$sessionId.lazy.tsx
@@ -69,6 +69,7 @@ function SessionComponent() {
   >("neutral");
   const [conceptUnderstood, setConceptUnderstood] = useState(false);
   const [questions, setQuestions] = useState<string[]>([]);
+  const [pauseTimer, setPauseTimer] = useState(false);
   const [
     chatHistoryOpened,
     { open: openChatHistory, close: closeChatHistory },
@@ -95,11 +96,14 @@ function SessionComponent() {
       labels: { confirm: "Exit Session", cancel: "Back" },
       confirmProps: { color: "blue" },
       onCancel: () => console.log("Cancel"),
-      onConfirm: async () => await closeSession("user_quit"),
+      onConfirm: async () => {
+        await closeSession("user_quit");
+      },
     });
 
   const closeSession = async (termination_reason: string) => {
     console.log("Closing session");
+    setPauseTimer(true);
     const session_duration = new Date().getTime() - startTime;
     // return;
 
@@ -334,8 +338,6 @@ function SessionComponent() {
     });
   }, [chatHistory]);
 
-  useEffect(() => {}, [conceptUnderstood]);
-
   return (
     <>
       <Navbar
@@ -425,6 +427,7 @@ function SessionComponent() {
           <Stack>
             <CountdownTimer
               minutes={10}
+              pauseTimer={pauseTimer}
               onTimeUp={async () => {
                 notifications.show({
                   title: "Time's up",


### PR DESCRIPTION
### Summary of changes
- Make all failure notifications reuse original notification ids
- Reset session creation state when create session api call fails
- Pause timer and recognizer when closing session
- Retry to check if post session analysis exists if fail as a fallback
- Added extra detail to student prompt about noisy transcripts

Closes #82 and closes #84 and closes #80